### PR TITLE
Extend collections handling to support hashes via edges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ test/tmp
 test/version_tmp
 tmp
 cache
+.idea/
+.ruby-gemset
+guacamole.iml

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec-its', git: 'https://github.com/rspec/rspec-its.git'
+

--- a/lib/guacamole/document_model_mapper.rb
+++ b/lib/guacamole/document_model_mapper.rb
@@ -2,6 +2,7 @@
 
 require 'guacamole/proxies/array'
 require 'guacamole/proxies/hash'
+require 'guacamole/proxies/single'
 
 module Guacamole
   # This is the default mapper class to map between Ashikawa::Core::Document and
@@ -301,10 +302,7 @@ module Guacamole
       when Virtus::Attribute::Hash::Type
         Proxies::Hash.new(model, edge_attribute.edge_class, opts)
       else
-        pp model
-        pp edge_attribute
-        pp opts
-        Proxies::Array.new(model, edge_attribute.edge_class, opts)
+        Proxies::Single.new(model, edge_attribute.edge_class, opts)
       end
     end
 

--- a/lib/guacamole/document_model_mapper.rb
+++ b/lib/guacamole/document_model_mapper.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
 
-require 'guacamole/proxies/relation'
+require 'guacamole/proxies/array'
+require 'guacamole/proxies/hash'
 
 module Guacamole
   # This is the default mapper class to map between Ashikawa::Core::Document and
@@ -155,7 +156,6 @@ module Guacamole
     # @return [Model] the resulting model with the given Model class
     def document_to_model(document)
       to_model(document.key, document.revision, document.to_h)
-      end
     end
 
     def hash_to_model(hash)
@@ -174,7 +174,6 @@ module Guacamole
         model
       end
     end
-
 
     # Map a model to a document
     #
@@ -298,9 +297,9 @@ module Guacamole
 
       case edge_attribute.type(model)
       when Virtus::Attribute::Collection::Type
-        Proxies::Relation.new(model, edge_attribute.edge_class, opts)
+        Proxies::Array.new(model, edge_attribute.edge_class, opts)
       when Virtus::Attribute::Hash::Type
-        Proxies::Relation.new(model, edge_attribute.edge_class, opts.merge(relation_type: :Hash))
+        Proxies::Hash.new(model, edge_attribute.edge_class, opts)
       end
     end
 

--- a/lib/guacamole/document_model_mapper.rb
+++ b/lib/guacamole/document_model_mapper.rb
@@ -300,6 +300,11 @@ module Guacamole
         Proxies::Array.new(model, edge_attribute.edge_class, opts)
       when Virtus::Attribute::Hash::Type
         Proxies::Hash.new(model, edge_attribute.edge_class, opts)
+      else
+        pp model
+        pp edge_attribute
+        pp opts
+        Proxies::Array.new(model, edge_attribute.edge_class, opts)
       end
     end
 

--- a/lib/guacamole/edge_collection.rb
+++ b/lib/guacamole/edge_collection.rb
@@ -26,8 +26,9 @@ module Guacamole
         @model_class = model_class
       end
 
+      Container = Struct.new(:edge_attributes, :model)
       def document_to_model(document)
-        [document['edge_attributes'].to_h, @model_mapper.hash_to_model(document['vertex'])]
+        Container.new(document['edge_attributes'], @model_mapper.hash_to_model(document['vertex']))
       end
 
       def model_class

--- a/lib/guacamole/identity_map.rb
+++ b/lib/guacamole/identity_map.rb
@@ -84,7 +84,6 @@ module Guacamole
       # @return [Object] the stored object
       def retrieve_or_store(klass, key, &block)
         return retrieve(klass, key) if include?(klass, key)
-
         store block.call
       end
 

--- a/lib/guacamole/proxies/array.rb
+++ b/lib/guacamole/proxies/array.rb
@@ -11,7 +11,6 @@ module Guacamole
         if relates_to_collection?
           return query_result.map{ |e| e.model }
         else
-          ::Kernel.puts "Array-nocollection #{query_result}"
           return query_result.first.model
         end
       end

--- a/lib/guacamole/proxies/array.rb
+++ b/lib/guacamole/proxies/array.rb
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+
+require 'guacamole/proxies/relation'
+require 'guacamole/edge_collection'
+
+module Guacamole
+  module Proxies
+    class Array < Relation
+
+      def resolve(query_result)
+        if relates_to_collection?
+          return query_result.map{ |e| e.model }
+        else
+          return query_result.first.model
+        end
+      end
+    end
+  end
+end
+

--- a/lib/guacamole/proxies/array.rb
+++ b/lib/guacamole/proxies/array.rb
@@ -11,6 +11,7 @@ module Guacamole
         if relates_to_collection?
           return query_result.map{ |e| e.model }
         else
+          ::Kernel.puts "Array-nocollection #{query_result}"
           return query_result.first.model
         end
       end

--- a/lib/guacamole/proxies/hash.rb
+++ b/lib/guacamole/proxies/hash.rb
@@ -11,7 +11,7 @@ module Guacamole
         if relates_to_collection?
           query_result.map{ |e| [e.edge_attributes['hash_key'], e.model] }.to_h
         else
-          ::Kernel.puts "Hash-nocollection #{query_result}"
+          # todo change to Guacamole::Proxies::Single for inverse relations
           query_result.first.model
         end
       end

--- a/lib/guacamole/proxies/hash.rb
+++ b/lib/guacamole/proxies/hash.rb
@@ -11,6 +11,7 @@ module Guacamole
         if relates_to_collection?
           query_result.map{ |e| [e.edge_attributes['hash_key'], e.model] }.to_h
         else
+          ::Kernel.puts "Hash-nocollection #{query_result}"
           query_result.first.model
         end
       end

--- a/lib/guacamole/proxies/hash.rb
+++ b/lib/guacamole/proxies/hash.rb
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+
+require 'guacamole/proxies/relation'
+require 'guacamole/edge_collection'
+
+module Guacamole
+  module Proxies
+    class Hash < Relation
+
+      def resolve(query_result)
+        if relates_to_collection?
+          query_result.map{ |e| [e.edge_attributes['hash_key'], e.model] }.to_h
+        else
+          query_result.first.model
+        end
+      end
+
+    end
+  end
+end

--- a/lib/guacamole/proxies/proxy.rb
+++ b/lib/guacamole/proxies/proxy.rb
@@ -21,7 +21,12 @@ module Guacamole
       end
 
       def method_missing(meth, *args, &blk)
-        target.call.send meth, *args, &blk
+        case meth
+        when :puts, :p, :pp
+          ::Kernel.send(meth, args, blk)
+        else
+          target.call.send meth, *args, &blk
+        end
       end
 
       def respond_to_missing?(name, include_private = false)

--- a/lib/guacamole/proxies/proxy.rb
+++ b/lib/guacamole/proxies/proxy.rb
@@ -20,22 +20,17 @@ module Guacamole
         undef_method(method) unless method =~ /^__/
       end
 
+      def target
+      end
+
       def method_missing(meth, *args, &blk)
-        case meth
-        when :puts, :p, :pp
-          ::Kernel.send(meth, args, blk)
-        else
-          target.call.send meth, *args, &blk
-        end
+        target.send(meth, *args, &blk)
       end
 
       def respond_to_missing?(name, include_private = false)
         target.respond_to?(name, include_private)
       end
 
-      def target
-        @target || ->() { nil }
-      end
-    end
+   end
   end
 end

--- a/lib/guacamole/proxies/relation.rb
+++ b/lib/guacamole/proxies/relation.rb
@@ -42,8 +42,7 @@ module Guacamole
       end
 
       def query_result
-        @query_result ||= query.to_a
-        @query_result
+        query.to_a
       end
 
       def method_missing(meth, *args, &blk)

--- a/lib/guacamole/proxies/relation.rb
+++ b/lib/guacamole/proxies/relation.rb
@@ -15,7 +15,15 @@ module Guacamole
 
         @target = lambda do
           neighbors = edge_collection.neighbors(@model, direction)
-          relates_to_collection? ? neighbors : neighbors.to_a.first
+          if relates_to_collection?
+            if is_a_hash?
+              neighbors.to_a.map{ |e| [e[0]['hash_key'], e[1]] }.to_h
+            else
+              neighbors.to_a.map{ |e| e[0] }
+            end
+          else
+            neighbors.to_a.first
+          end
         end
       end
 
@@ -29,6 +37,10 @@ module Guacamole
 
       def relates_to_collection?
         !@options[:just_one]
+      end
+
+      def is_a_hash?
+        @options[:relation_type]==:Hash
       end
     end
   end

--- a/lib/guacamole/proxies/single.rb
+++ b/lib/guacamole/proxies/single.rb
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+
+require 'guacamole/proxies/relation'
+require 'guacamole/edge_collection'
+
+module Guacamole
+  module Proxies
+    class Single < Relation
+
+      def resolve(query_result)
+        return query_result.first.model unless query_result.empty?
+        nil
+      end
+
+    end
+  end
+end

--- a/lib/guacamole/transaction.rb
+++ b/lib/guacamole/transaction.rb
@@ -347,7 +347,6 @@ module Guacamole
     #
     # @api private
     def execute_transaction
-      pp transaction_params.as_json
       transaction.execute(transaction_params.as_json)
     end
 

--- a/lib/guacamole/transaction.rb
+++ b/lib/guacamole/transaction.rb
@@ -216,13 +216,14 @@ module Guacamole
         value = edge_attribute.get_value(start_model)
         return [] unless value
         attr_type = edge_attribute.type(start_model)
+
         case attr_type
         when Virtus::Attribute::Hash::Type
           [ value.map{ |k,v| ModelWithAttributes.new(v, { hash_key: k }) } ].compact.flatten
         when Virtus::Attribute::Collection::Type
           [ value.map{ |v|  ModelWithAttributes.new(v, {}) } ].compact.flatten
         else
-          value ? ModelWithAttributes.new(value, {}) : []
+          [ ModelWithAttributes.new(value, {}) ]
         end
       end
 
@@ -270,7 +271,7 @@ module Guacamole
       #
       # @return [Array<Hash>] A list of hashes representing the edges
       def edges
-        from_vertices.product(to_vertices).map do |from_vertex, to_vertex|
+        t = from_vertices.product(to_vertices).map do |from_vertex, to_vertex|
           { _from: from_vertex.id_for_edge, _to: to_vertex.id_for_edge, attributes: to_vertex.edge_attributes }
         end
       end
@@ -346,6 +347,7 @@ module Guacamole
     #
     # @api private
     def execute_transaction
+      pp transaction_params.as_json
       transaction.execute(transaction_params.as_json)
     end
 

--- a/spec/acceptance/relations_spec.rb
+++ b/spec/acceptance/relations_spec.rb
@@ -227,9 +227,7 @@ describe 'Graph based relations' do
       it 'should create the new target and connect it with the start' do
         the_hunger_games.author = suzanne_collins
         BooksCollection.save the_hunger_games
-
         book = BooksCollection.by_key the_hunger_games.key
-
         expect(book.author.name).to eq suzanne_collins.name
       end
     end

--- a/spec/unit/edge_collection_spec.rb
+++ b/spec/unit/edge_collection_spec.rb
@@ -48,7 +48,7 @@ describe Guacamole::EdgeCollection do
         expect(edge_collection.ancestors).to include Guacamole::EdgeCollection
       end
 
-      it 'should return the edge collection for a givene edge class' do
+      it 'should return the edge collection for a given edge class' do
         allow(subject).to receive(:create_edge_collection).
                            with('AmazingEdgesCollection').
                            and_return(auto_defined_edge_collection)

--- a/spec/unit/edge_collection_spec.rb
+++ b/spec/unit/edge_collection_spec.rb
@@ -208,7 +208,9 @@ describe Guacamole::EdgeCollection do
         end
 
         it 'should set the mapper to the appropriate mapper of model' do
-          expect(Guacamole::AqlQuery).to receive(:new).with(anything, mapper, anything)
+          model_class = double
+          stub_const('Model', double)
+          expect(Guacamole::AqlQuery).to receive(:new).with(anything,instance_of(Guacamole::EdgeCollection::AnnotatedEdgeMapper), anything)
 
           subject.neighbors(model)
         end

--- a/spec/unit/proxies/array_spec.rb
+++ b/spec/unit/proxies/array_spec.rb
@@ -1,0 +1,86 @@
+# -*- encoding : utf-8 -*-
+
+require 'spec_helper'
+require 'guacamole/proxies/array'
+
+describe Guacamole::Proxies::Array do
+  let(:model) { double('Model') }
+  let(:edge_class) { double('EdgeClass') }
+  let(:responsible_edge_collection) { double('EdgeCollection') }
+  let(:edge_collection_name)        { 'name_of_the_edge_collection' }
+
+  before do
+    allow(Guacamole::EdgeCollection).to receive(:for).with(edge_class).and_return(responsible_edge_collection)
+    allow(responsible_edge_collection).to receive(:collection_name).and_return(edge_collection_name)
+  end
+
+  context 'initialization' do
+    subject { Guacamole::Proxies::Array }
+
+    it 'should take a model and edge class as params' do
+      expect { subject.new(model, edge_class) }.not_to raise_error
+    end
+  end
+
+  context 'initialized proxy' do
+    let(:proxy_options) { {} }
+    let(:neighbors) { double('Neighbors', options:{}) }
+    let(:related_model) { double('RelatedModel', name: 'The Model') }
+    let(:query_result) { double('EdgeDocument', edge_attributes: {}, model: related_model) }
+
+    before do
+      allow(responsible_edge_collection).to receive(:neighbors).with(model, :outbound). and_return(neighbors)
+      allow(neighbors).to receive(:call).and_return(neighbors)
+    end
+
+    subject { Guacamole::Proxies::Array.new(model, edge_class, proxy_options) }
+
+    # The following is not possible with `its` because `send` is not available
+    it 'should have an edge_collection' do
+      expect(subject.edge_collection).to eq responsible_edge_collection
+    end
+
+    it 'should have a direction' do
+      expect(subject.direction).to eq :outbound
+    end
+
+    it 'should know it the proxy relates to a collection' do
+      expect(subject.relates_to_collection?).to eq true
+    end
+
+    context 'with relation to collection' do
+      let(:proxy_options) { { just_one: false } }
+      let(:related_models) { double('RelatedModels', count: 1) }
+
+      before do
+        allow(neighbors).to receive(:to_a).and_return(neighbors)
+        allow(responsible_edge_collection).to receive(:neighbors).
+          with(model, subject.direction).
+          and_return(neighbors)
+        allow(neighbors).to receive(:map).and_return([related_model])
+      end
+
+      it 'should call the #neighbors method on the appropriate edge collection' do
+        expect(subject.count).to eq related_models.count
+      end
+    end
+
+    context 'with relation to single model' do
+      let(:proxy_options) { { just_one: true } }
+
+      before do
+        allow(neighbors).to receive(:first).and_return(query_result)
+        allow(neighbors).to receive(:to_a).and_return(neighbors)
+        allow(responsible_edge_collection).to receive(:neighbors).
+          with(model, subject.direction).
+          and_return(neighbors)
+        allow(neighbors).to receive(:map).and_yield(related_model)
+      end
+
+      it 'should call the #neighbors method on the appropriate edge collection' do
+        expect(subject.name).to eq related_model.name
+      end
+    end
+  end
+end
+

--- a/spec/unit/proxies/hash_spec.rb
+++ b/spec/unit/proxies/hash_spec.rb
@@ -1,0 +1,98 @@
+# -*- encoding : utf-8 -*-
+
+require 'spec_helper'
+require 'guacamole/proxies/relation'
+
+describe Guacamole::Proxies::Hash do
+  let(:model) { double('Model') }
+  let(:edge_class) { double('EdgeClass') }
+  let(:responsible_edge_collection) { double('EdgeCollection') }
+  let(:edge_collection_name)        { 'name_of_the_edge_collection' }
+
+  before do
+    allow(Guacamole::EdgeCollection).to receive(:for).with(edge_class).and_return(responsible_edge_collection)
+    allow(responsible_edge_collection).to receive(:collection_name).and_return(edge_collection_name)
+  end
+
+  context 'initialization' do
+    subject { Guacamole::Proxies::Hash }
+
+    it 'should take a model and edge class as params' do
+      expect { subject.new(model, edge_class) }.not_to raise_error
+    end
+  end
+
+  context 'initialized proxy' do
+    let(:proxy_options) { {} }
+    let(:neighbors) { double('Neighbors', options:{}) }
+    let(:related_model) { double('RelatedModel', name: 'The Model') }
+
+    let(:foo) {double( edge_attributes: { 'hash_key' => 'foo' }, model:related_model)}
+    let(:bar) {double( edge_attributes: { 'hash_key' => 'bar' }, model:related_model)}
+
+    before do
+      allow(responsible_edge_collection).to receive(:neighbors).with(model, :outbound). and_return(neighbors)
+      allow(neighbors).to receive(:call).and_return(neighbors)
+    end
+
+    subject { Guacamole::Proxies::Hash.new(model, edge_class, proxy_options) }
+
+    # The following is not possible with `its` because `send` is not available
+    it 'should have an edge_collection' do
+      expect(subject.edge_collection).to eq responsible_edge_collection
+    end
+
+    it 'should have a direction' do
+      expect(subject.direction).to eq :outbound
+    end
+
+    it 'should know it the proxy relates to a collection' do
+      expect(subject.relates_to_collection?).to eq true
+    end
+
+    context 'with relation to collection' do
+      let(:proxy_options) { { just_one: false } }
+      let(:related_models) { double('RelatedModels', count: 1) }
+
+      before do
+        allow(neighbors).to receive(:to_a).and_return(neighbors)
+        allow(responsible_edge_collection).to receive(:neighbors).
+          with(model, subject.direction).
+          and_return(neighbors)
+        allow(neighbors).to receive(:map).and_return({'foo' => related_model})
+      end
+
+      it 'should call the #neighbors method on the appropriate edge collection' do
+        expect(subject.count).to eq related_models.count
+      end
+
+      context 'as hash' do
+        let(:proxy_options) { {just_one: false, relation_type: :Hash } }
+        before do
+          allow(neighbors).to receive(:map).and_return({'foo' => related_model, 'bar' => related_model})
+        end
+
+        it 'should map neighbors to a hash' do
+          expect(subject.keys).to eq ['foo', 'bar']
+        end
+      end
+    end
+
+    context 'with relation to single model' do
+      let(:proxy_options) { { just_one: true } }
+
+      before do
+        allow(neighbors).to receive(:first).and_return(foo)
+        allow(neighbors).to receive(:to_a).and_return(neighbors)
+        allow(responsible_edge_collection).to receive(:neighbors).
+          with(model, subject.direction).
+          and_return(neighbors)
+        allow(neighbors).to receive(:map).and_yield(foo)
+      end
+
+      it 'should call the #neighbors method on the appropriate edge collection' do
+        expect(subject.name).to eq related_model.name
+      end
+    end
+  end
+end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -137,6 +137,8 @@ describe Guacamole::Transaction::SubGraphTargetState do
   let(:edge_collection) { double('EdgeCollection') }
   let(:edge_collection_name) { double('EdgeCollectionName') }
 
+  let(:edge_hash_attribute) { double('EdgeAttribute') }
+
   let(:from_document) { double('Document') }
   let(:to_document) { double('Document') }
 
@@ -166,287 +168,463 @@ describe Guacamole::Transaction::SubGraphTargetState do
   its(:edge_collection_name) { should eq edge_collection_name }
   its(:edge_class) { should eq edge_class }
 
-  it 'should have a representation suitable for JSON serialization' do
-    from_vertices = double('FromVertices')
-    to_vertices   = double('ToVertices')
-
-    allow(subject).to receive(:from_vertices).and_return(double(as_json: from_vertices))
-    allow(subject).to receive(:to_vertices).and_return(double(as_json: to_vertices))
-    allow(subject).to receive(:edges).and_return(edges = double)
-    allow(subject).to receive(:old_edge_keys).and_return(old_edge_keys = double)
-
-    state_as_json = {
-      name: edge_collection_name,
-      fromVertices: from_vertices,
-      toVertices: to_vertices,
-      edges: edges,
-      oldEdges: old_edge_keys
-    }
-
-    expect(subject.as_json).to eq state_as_json
-  end
-
-  it 'should select the responsible mapper for a given model' do
-    expect(edge_collection).to receive(:mapper_for_start).with(model)
-
-    subject.mapper_for_model(model)
-  end
-
-  it 'should map the given model to a document' do
-    mapper = double('Mapper')
-    allow(subject).to receive(:mapper_for_model).with(model).and_return(mapper)
-    expect(mapper).to receive(:model_to_document).with(model)
-
-    subject.model_to_document(model)
-  end
-
-  it 'should get a single related model of the edge_attribute as array' do
-    related_model = instance_double('Model')
-    allow(edge_attribute).to receive(:get_value).with(model).and_return(related_model)
-
-    expect(subject.related_models).to eq [related_model]
-  end
-
-  it 'should get multiple related models of the edge_attribute as array' do
-    related_model1 = instance_double('Model')
-    related_model2 = instance_double('Model')
-    allow(edge_attribute).to receive(:get_value).with(model).and_return([related_model1, related_model2])
-
-    expect(subject.related_models).to eq [related_model1, related_model2]
-  end
-
-  describe 'building of edges' do
-    let(:from_vertex1) { double('Vertex', id_for_edge: '42') }
-    let(:from_vertex2) { double('Vertex', id_for_edge: '23') }
-    let(:to_vertex) { double('Vertex', id_for_edge: '101') }
+  context "Array edge attribute" do
 
     before do
-      allow(subject).to receive(:from_vertices).and_return([from_vertex1, from_vertex2])
-      allow(subject).to receive(:to_vertices).and_return([to_vertex])
+      allow(edge_attribute).to receive(:type).with(any_args).and_return(Virtus::Attribute::Collection::Type.new(to_model_class))
     end
 
-    it 'should build a list of edges to connect all from vertices to the to vertices' do
-      pattern = [
-        {
-          _from: from_vertex1.id_for_edge,
-          _to: to_vertex.id_for_edge
-        }.ignore_extra_keys!,
-        {
-          _from: from_vertex2.id_for_edge,
-          _to: to_vertex.id_for_edge
-        }.ignore_extra_keys!
-      ]
+    it 'should have a representation suitable for JSON serialization' do
+      from_vertices = double('FromVertices')
+      to_vertices   = double('ToVertices')
 
-      expect(subject.edges).to match_json_expression(pattern)
+      allow(subject).to receive(:from_vertices).and_return(double(as_json: from_vertices))
+      allow(subject).to receive(:to_vertices).and_return(double(as_json: to_vertices))
+      allow(subject).to receive(:edges).and_return(edges = double)
+      allow(subject).to receive(:old_edge_keys).and_return(old_edge_keys = double)
+
+      state_as_json = {
+        name: edge_collection_name,
+        fromVertices: from_vertices,
+        toVertices: to_vertices,
+        edges: edges,
+        oldEdges: old_edge_keys
+      }
+
+      expect(subject.as_json).to eq state_as_json
     end
 
-    it 'should have a list of edges all with empty attributes' do
-      expect(subject.edges).to all(include(attributes: {}))
+    it 'should select the responsible mapper for a given model' do
+      expect(edge_collection).to receive(:mapper_for_start).with(model)
+
+      subject.mapper_for_model(model)
+    end
+
+    it 'should map the given model to a document' do
+      mapper = double('Mapper')
+      allow(subject).to receive(:mapper_for_model).with(model).and_return(mapper)
+      expect(mapper).to receive(:model_to_document).with(model)
+
+      subject.model_to_document(model)
+    end
+
+    it 'should get a single related model of the edge_attribute as array' do
+      allow(edge_attribute).to receive(:type).with(any_args).and_return(:Model)
+      related_model = instance_double('Model')
+      allow(edge_attribute).to receive(:get_value).with(model).and_return(related_model)
+      expect(subject.related_models).to eq [related_model, {}]
+    end
+
+    it 'should get multiple related models of the edge_attribute as array' do
+      related_model1 = instance_double('Model')
+      related_model2 = instance_double('Model')
+      allow(edge_attribute).to receive(:get_value).with(model).and_return([related_model1, related_model2])
+
+      expect(subject.related_models).to eq [related_model1, {}, related_model2, {}]
+    end
+
+    describe 'building of edges' do
+      let(:from_vertex1) { double('Vertex', id_for_edge: '42') }
+      let(:from_vertex2) { double('Vertex', id_for_edge: '23') }
+      let(:to_vertex) { double('Vertex', id_for_edge: '101', edge_attributes: {}) }
+
+      before do
+        allow(subject).to receive(:from_vertices).and_return([from_vertex1, from_vertex2])
+        allow(subject).to receive(:to_vertices).and_return([to_vertex])
+      end
+
+      it 'should build a list of edges to connect all from vertices to the to vertices' do
+        pattern = [
+          {
+            _from: from_vertex1.id_for_edge,
+            _to: to_vertex.id_for_edge
+          }.ignore_extra_keys!,
+          {
+            _from: from_vertex2.id_for_edge,
+            _to: to_vertex.id_for_edge
+          }.ignore_extra_keys!
+        ]
+
+        expect(subject.edges).to match_json_expression(pattern)
+      end
+
+      it 'should have a list of edges all with empty attributes' do
+        expect(subject.edges).to all(include(attributes: {}))
+      end
+    end
+
+    describe 'building of vertices' do
+      let(:from_vertex) { double('Vertex') }
+      let(:to_vertex) { double('Vertex', edge_attributes: {}) }
+      let(:query_result) { double('Query') }
+
+      before do
+        allow(query_result).to receive(:key)
+        allow(query_result).to receive(:map).and_yield(query_result)
+
+        allow(subject).to receive(:model_to_document).with(from_model).and_return(from_document)
+        allow(subject).to receive(:model_to_document).with(to_model).and_return(to_document)
+
+        allow(Guacamole::Transaction::Vertex).to receive(:new).
+          with(from_model, from_collection_name, from_document, nil).
+          and_return(from_vertex)
+        allow(Guacamole::Transaction::Vertex).to receive(:new).
+          with(to_model, to_collection_name, to_document, {}).
+          and_return(to_vertex)
+      end
+
+      context 'model is the :from part of the edge' do
+        let(:from_model) { model }
+        let(:to_model) { double('ToModel') }
+
+        before do
+          allow(from_model_class).to receive(:===).with(model).and_return(true)
+          allow(to_model_class).to receive(:===).with(model).and_return(false)
+          allow(subject).to receive(:related_models).and_return([to_model, {}])
+        end
+
+        it 'should transform model to the :from vertices' do
+          expect(subject.from_vertices).to eq [from_vertex]
+        end
+
+        it 'should transform the related models to :to vertices' do
+          expect(subject.to_vertices).to eq [to_vertex]
+        end
+
+        it 'should select the old edge keys based on :from for the model' do
+          expect(edge_collection).to receive(:by_example).with(_from: model_id).and_return(query_result)
+
+          subject.old_edge_keys
+        end
+      end
+
+      context 'model is the :to part of the edge' do
+        let(:from_model) { double('FromModel') }
+        let(:to_model) { model }
+
+        before do
+          allow(from_model_class).to receive(:===).with(model).and_return(false)
+          allow(to_model_class).to receive(:===).with(model).and_return(true)
+          allow(subject).to receive(:related_models).and_return([from_model])
+        end
+
+        it 'should transform model to the :to vertices' do
+          expect(subject.to_vertices).to eq [to_vertex]
+        end
+
+        it 'should transform the related models to :from vertices' do
+          expect(subject.from_vertices).to eq [from_vertex]
+        end
+
+        it 'should select the old edges based on :to for the model' do
+          expect(edge_collection).to receive(:by_example).with(_to: model_id).and_return(query_result)
+
+          subject.old_edge_keys
+        end
+      end
     end
   end
 
-  describe 'building of vertices' do
-    let(:from_vertex) { double('Vertex') }
-    let(:to_vertex) { double('Vertex') }
-    let(:query_result) { double('Query') }
-
+  context "Hash edge attribute" do
     before do
-      allow(query_result).to receive(:key)
-      allow(query_result).to receive(:map).and_yield(query_result)
-
-      allow(subject).to receive(:model_to_document).with(from_model).and_return(from_document)
-      allow(subject).to receive(:model_to_document).with(to_model).and_return(to_document)
-
-      allow(Guacamole::Transaction::Vertex).to receive(:new).
-                                                with(from_model, from_collection_name, from_document).
-                                                and_return(from_vertex)
-      allow(Guacamole::Transaction::Vertex).to receive(:new).
-                                                with(to_model, to_collection_name, to_document).
-                                                and_return(to_vertex)
+      allow(edge_attribute).to receive(:type).with(any_args).and_return(Virtus::Attribute::Hash::Type.new(String, to_model_class))
     end
 
-    context 'model is the :from part of the edge' do
-      let(:from_model) { model }
-      let(:to_model) { double('ToModel') }
+    it 'should have a representation suitable for JSON serialization' do
+      from_vertices = double('FromVertices')
+      to_vertices   = double('ToVertices')
+
+      allow(subject).to receive(:from_vertices).and_return(double(as_json: from_vertices))
+      allow(subject).to receive(:to_vertices).and_return(double(as_json: to_vertices))
+      allow(subject).to receive(:edges).and_return(edges = double)
+      allow(subject).to receive(:old_edge_keys).and_return(old_edge_keys = double)
+
+      state_as_json = {
+        name: edge_collection_name,
+        fromVertices: from_vertices,
+        toVertices: to_vertices,
+        edges: edges,
+        oldEdges: old_edge_keys
+      }
+
+      expect(subject.as_json).to eq state_as_json
+    end
+
+    it 'should select the responsible mapper for a given model' do
+      expect(edge_collection).to receive(:mapper_for_start).with(model)
+
+      subject.mapper_for_model(model)
+    end
+
+    it 'should map the given model to a document' do
+      mapper = double('Mapper')
+      allow(subject).to receive(:mapper_for_model).with(model).and_return(mapper)
+      expect(mapper).to receive(:model_to_document).with(model)
+
+      subject.model_to_document(model)
+    end
+
+    it 'should get an empty related model of the edge_attribute as array' do
+      related_model = instance_double('Model')
+      allow(edge_attribute).to receive(:get_value).with(model).and_return( {} )
+
+      expect(subject.related_models).to eql []
+    end
+
+    it 'should get a single related model of the edge_attribute as array' do
+      related_model = instance_double('Model')
+      allow(edge_attribute).to receive(:get_value).with(model).and_return( { key: related_model } )
+
+      expect(subject.related_models).to eql [ related_model, {hash_key: :key} ]
+    end
+
+    it 'should get multiple related models of the edge_attribute as array' do
+      related_model1 = instance_double('Model')
+      related_model2 = instance_double('Model')
+      allow(edge_attribute).to receive(:get_value).with(model).and_return( { key: related_model1, other_key: related_model2 } )
+
+      expect(subject.related_models).to eql [ related_model1, { hash_key: :key }, related_model2, { hash_key: :other_key } ]
+    end
+
+    describe 'building of edges' do
+      let(:from_vertex1) { double('Vertex', id_for_edge: '42') }
+      let(:from_vertex2) { double('Vertex', id_for_edge: '23') }
+      let(:to_vertex) { double('Vertex', id_for_edge: '101', edge_attributes: { hash_key: "name" }) }
 
       before do
-        allow(from_model_class).to receive(:===).with(model).and_return(true)
-        allow(to_model_class).to receive(:===).with(model).and_return(false)
-        allow(subject).to receive(:related_models).and_return([to_model])
+        allow(subject).to receive(:from_vertices).and_return([from_vertex1, from_vertex2])
+        allow(subject).to receive(:to_vertices).and_return([to_vertex])
       end
 
-      it 'should transform model to the :from vertices' do
-        expect(subject.from_vertices).to eq [from_vertex]
+      it 'should build a list of edges to connect all from vertices to the to vertices' do
+        pattern = [
+          {
+            _from: from_vertex1.id_for_edge,
+            _to: to_vertex.id_for_edge,
+            attributes: {
+              hash_key: "name"
+            }
+          }.ignore_extra_keys!,
+          {
+            _from: from_vertex2.id_for_edge,
+            _to: to_vertex.id_for_edge,
+            attributes: {
+              hash_key: "name"
+            }
+          }.ignore_extra_keys!
+        ]
+
+        expect(subject.edges).to match_json_expression(pattern)
       end
 
-      it 'should transform the related models to :to vertices' do
-        expect(subject.to_vertices).to eq [to_vertex]
-      end
-
-      it 'should select the old edge keys based on :from for the model' do
-        expect(edge_collection).to receive(:by_example).with(_from: model_id).and_return(query_result)
-
-        subject.old_edge_keys
+      it 'should have a list of edges all with attributes' do
+        expect(subject.edges).to all(include(attributes: {hash_key: "name"}))
       end
     end
 
-    context 'model is the :to part of the edge' do
-      let(:from_model) { double('FromModel') }
-      let(:to_model) { model }
+    describe 'building of vertices' do
+      let(:from_vertex) { double('Vertex') }
+      let(:to_vertex) { double('Vertex') }
+      let(:query_result) { double('Query') }
 
       before do
-        allow(from_model_class).to receive(:===).with(model).and_return(false)
-        allow(to_model_class).to receive(:===).with(model).and_return(true)
-        allow(subject).to receive(:related_models).and_return([from_model])
+        allow(query_result).to receive(:key)
+        allow(query_result).to receive(:map).and_yield(query_result)
+
+        allow(subject).to receive(:model_to_document).with(from_model).and_return(from_document)
+        allow(subject).to receive(:model_to_document).with(to_model).and_return(to_document)
+
+        allow(Guacamole::Transaction::Vertex).to receive(:new).
+          with(from_model, from_collection_name, from_document, nil).
+          and_return(from_vertex)
+        allow(Guacamole::Transaction::Vertex).to receive(:new).
+          with(to_model, to_collection_name, to_document, {}).
+          and_return(to_vertex)
       end
 
-      it 'should transform model to the :to vertices' do
-        expect(subject.to_vertices).to eq [to_vertex]
+      context 'model is the :from part of the edge' do
+        let(:from_model) { model }
+        let(:to_model) { double('ToModel') }
+
+        before do
+          allow(from_model_class).to receive(:===).with(model).and_return(true)
+          allow(to_model_class).to receive(:===).with(model).and_return(false)
+          allow(subject).to receive(:related_models).and_return([to_model])
+        end
+
+        it 'should transform model to the :from vertices' do
+          expect(subject.from_vertices).to eq [from_vertex]
+        end
+
+        it 'should transform the related models to :to vertices' do
+          expect(subject.to_vertices).to eq [to_vertex]
+        end
+
+        it 'should select the old edge keys based on :from for the model' do
+          expect(edge_collection).to receive(:by_example).with(_from: model_id).and_return(query_result)
+
+          subject.old_edge_keys
+        end
       end
 
-      it 'should transform the related models to :from vertices' do
-        expect(subject.from_vertices).to eq [from_vertex]
-      end
+      context 'model is the :to part of the edge' do
+        let(:from_model) { double('FromModel') }
+        let(:to_model) { model }
 
-      it 'should select the old edges based on :to for the model' do
-        expect(edge_collection).to receive(:by_example).with(_to: model_id).and_return(query_result)
+        before do
+          allow(from_model_class).to receive(:===).with(model).and_return(false)
+          allow(to_model_class).to receive(:===).with(model).and_return(true)
+          allow(subject).to receive(:related_models).and_return([from_model])
+        end
 
-        subject.old_edge_keys
+        it 'should transform model to the :to vertices' do
+          expect(subject.to_vertices).to eq [to_vertex]
+        end
+
+        it 'should transform the related models to :from vertices' do
+          expect(subject.from_vertices).to eq [from_vertex]
+        end
+
+        it 'should select the old edges based on :to for the model' do
+          expect(edge_collection).to receive(:by_example).with(_to: model_id).and_return(query_result)
+
+          subject.old_edge_keys
+        end
       end
     end
   end
 end
 
-describe Guacamole::Transaction do
-  let(:collection) { double('Collection') }
-  let(:model) { instance_double('Model') }
-  let(:database) { double('Database') }
-  let(:init_options) { { collection: collection, model: model } }
+  describe Guacamole::Transaction do
+    let(:collection) { double('Collection') }
+    let(:model) { instance_double('Model') }
+    let(:database) { double('Database') }
+    let(:init_options) { { collection: collection, model: model } }
 
-  subject { Guacamole::Transaction.new(init_options) }
-
-  before do
-    allow(collection).to receive(:connection)
-    allow(collection).to receive(:database).and_return(database)
-  end
-
-  describe '#run' do
-    subject { Guacamole::Transaction }
-
-    let(:transaction_instance) { instance_double('Guacamole::Transaction') }
-
-    it 'should build a new transaction and execute it' do
-      allow(subject).to receive(:new).with(init_options).and_return(transaction_instance)
-      expect(transaction_instance).to receive(:execute_transaction)
-
-      subject.run(init_options)
-    end
-  end
-
-  describe 'initialization' do
-    its(:collection) { should eq collection }
-    its(:model)      { should eq model }
-    its(:database)   { should eq database }
-
-    it 'should init the connection to the database' do
-      expect(collection).to receive(:connection)
-
-      Guacamole::Transaction.new(init_options)
-    end
-  end
-
-  describe 'edge_collections for the transaction' do
-    it 'should pass model and collection to TargetStatesBuilder to create the edge_collections' do
-      expect(Guacamole::Transaction::TargetStatesBuilder).to receive(:build).with(model, collection)
-
-      subject.edge_collections
-    end
-  end
-
-  describe 'determine write and read collections for the transaction' do
-    let(:edge_collection) { instance_double('Guacamole::Transaction::SubGraphTargetState') }
-    let(:from_vertex) { instance_double('Guacamole::Transaction::Vertex') }
-    let(:to_vertex) { instance_double('Guacamole::Transaction::Vertex') }
-
-    let(:edge_collection_name) { double('EdgeCollectionName') }
-    let(:from_vertex_collection_name) { double('FromName') }
-    let(:to_vertex_collection_name) { double('ToName') }
+    subject { Guacamole::Transaction.new(init_options) }
 
     before do
-      allow(subject).to receive(:edge_collections).and_return([edge_collection])
-      allow(edge_collection).to receive(:edge_collection_name).and_return(edge_collection_name)
-      allow(edge_collection).to receive(:from_vertices).and_return([from_vertex])
-      allow(edge_collection).to receive(:to_vertices).and_return([to_vertex])
-      allow(from_vertex).to receive(:collection).and_return(from_vertex_collection_name)
-      allow(to_vertex).to receive(:collection).and_return(to_vertex_collection_name)
+      allow(collection).to receive(:connection)
+      allow(collection).to receive(:database).and_return(database)
     end
 
-    it 'should collect all edge_collection and vertex collection names of all target states as write collection' do
-      expect(subject.write_collections).to eq [edge_collection_name,
-                                               from_vertex_collection_name,
-                                               to_vertex_collection_name]
+    describe '#run' do
+      subject { Guacamole::Transaction }
+
+      let(:transaction_instance) { instance_double('Guacamole::Transaction') }
+
+      it 'should build a new transaction and execute it' do
+        allow(subject).to receive(:new).with(init_options).and_return(transaction_instance)
+        expect(transaction_instance).to receive(:execute_transaction)
+
+        subject.run(init_options)
+      end
     end
 
-    it 'should have the same read collection as the write collections' do
-      expect(subject.read_collections).to eq subject.write_collections
+    describe 'initialization' do
+      its(:collection) { should eq collection }
+      its(:model)      { should eq model }
+      its(:database)   { should eq database }
+
+      it 'should init the connection to the database' do
+        expect(collection).to receive(:connection)
+
+        Guacamole::Transaction.new(init_options)
+      end
+    end
+
+    describe 'edge_collections for the transaction' do
+      it 'should pass model and collection to TargetStatesBuilder to create the edge_collections' do
+        expect(Guacamole::Transaction::TargetStatesBuilder).to receive(:build).with(model, collection)
+
+        subject.edge_collections
+      end
+    end
+
+    describe 'determine write and read collections for the transaction' do
+      let(:edge_collection) { instance_double('Guacamole::Transaction::SubGraphTargetState') }
+      let(:from_vertex) { instance_double('Guacamole::Transaction::Vertex') }
+      let(:to_vertex) { instance_double('Guacamole::Transaction::Vertex') }
+
+      let(:edge_collection_name) { double('EdgeCollectionName') }
+      let(:from_vertex_collection_name) { double('FromName') }
+      let(:to_vertex_collection_name) { double('ToName') }
+
+      before do
+        allow(subject).to receive(:edge_collections).and_return([edge_collection])
+        allow(edge_collection).to receive(:edge_collection_name).and_return(edge_collection_name)
+        allow(edge_collection).to receive(:from_vertices).and_return([from_vertex])
+        allow(edge_collection).to receive(:to_vertices).and_return([to_vertex])
+        allow(from_vertex).to receive(:collection).and_return(from_vertex_collection_name)
+        allow(to_vertex).to receive(:collection).and_return(to_vertex_collection_name)
+      end
+
+      it 'should collect all edge_collection and vertex collection names of all target states as write collection' do
+        expect(subject.write_collections).to eq [edge_collection_name,
+                                                 from_vertex_collection_name,
+                                                 to_vertex_collection_name]
+      end
+
+      it 'should have the same read collection as the write collections' do
+        expect(subject.read_collections).to eq subject.write_collections
+      end
+    end
+
+    describe 'send the transaction to the database' do
+      let(:graph) { double('Graph', name: 'graph') }
+      let(:shared_path) { double('Path') }
+      let(:config) { double('Config', graph: graph, shared_path: shared_path) }
+
+      before do
+        allow(Guacamole).to receive(:configuration).and_return(config)
+      end
+
+      it 'should create the parameters for the transaction' do
+        edge_collections = double('EdgeCollections')
+        allow(subject).to receive(:edge_collections).and_return(edge_collections)
+
+        expect(subject.transaction_params).to eq(edgeCollections: edge_collections,
+                                                 graph: graph.name,
+                                                 log_level: 'debug')
+      end
+
+      it 'should prepare the transaction on the database' do
+        transaction_code = double('TransactionCode')
+        write_collections = double('WriteCollections')
+        read_collections = double('ReadCollections')
+        allow(subject).to receive(:transaction_code).and_return(transaction_code)
+        allow(subject).to receive(:write_collections).and_return(write_collections)
+        allow(subject).to receive(:read_collections).and_return(read_collections)
+
+        transaction_options = { write: write_collections, read: read_collections }
+
+        db_transaction = double('DBTransaction')
+        allow(database).to receive(:create_transaction).
+          with(transaction_code, transaction_options).
+          and_return(db_transaction)
+        allow(db_transaction).to receive(:wait_for_sync=).with(true)
+
+        subject.transaction
+      end
+
+      it 'should load the transaction code' do
+        path_to_transaction = double('TransactionCode')
+        allow(shared_path).to receive(:join).with('transaction.js').and_return(path_to_transaction)
+        expect(File).to receive(:read).with(path_to_transaction)
+
+        subject.transaction_code
+      end
+
+      it 'should execute the transaction with the parameters' do
+        transaction        = double('DBTransaction')
+        transaction_params = double('TransactionParams')
+
+        allow(subject).to receive(:transaction).and_return(transaction)
+        allow(subject).to receive(:transaction_params).and_return(transaction_params)
+        allow(transaction_params).to receive(:as_json).and_return(transaction_params)
+        expect(transaction).to receive(:execute).with(transaction_params)
+
+        subject.execute_transaction
+      end
     end
   end
-
-  describe 'send the transaction to the database' do
-    let(:graph) { double('Graph', name: 'graph') }
-    let(:shared_path) { double('Path') }
-    let(:config) { double('Config', graph: graph, shared_path: shared_path) }
-
-    before do
-      allow(Guacamole).to receive(:configuration).and_return(config)
-    end
-
-    it 'should create the parameters for the transaction' do
-      edge_collections = double('EdgeCollections')
-      allow(subject).to receive(:edge_collections).and_return(edge_collections)
-
-      expect(subject.transaction_params).to eq(edgeCollections: edge_collections,
-                                               graph: graph.name,
-                                               log_level: 'debug')
-    end
-
-    it 'should prepare the transaction on the database' do
-      transaction_code = double('TransactionCode')
-      write_collections = double('WriteCollections')
-      read_collections = double('ReadCollections')
-      allow(subject).to receive(:transaction_code).and_return(transaction_code)
-      allow(subject).to receive(:write_collections).and_return(write_collections)
-      allow(subject).to receive(:read_collections).and_return(read_collections)
-
-      transaction_options = { write: write_collections, read: read_collections }
-
-      db_transaction = double('DBTransaction')
-      allow(database).to receive(:create_transaction).
-                          with(transaction_code, transaction_options).
-                          and_return(db_transaction)
-      allow(db_transaction).to receive(:wait_for_sync=).with(true)
-
-      subject.transaction
-    end
-
-    it 'should load the transaction code' do
-      path_to_transaction = double('TransactionCode')
-      allow(shared_path).to receive(:join).with('transaction.js').and_return(path_to_transaction)
-      expect(File).to receive(:read).with(path_to_transaction)
-
-      subject.transaction_code
-    end
-
-    it 'should execute the transaction with the parameters' do
-      transaction        = double('DBTransaction')
-      transaction_params = double('TransactionParams')
-
-      allow(subject).to receive(:transaction).and_return(transaction)
-      allow(subject).to receive(:transaction_params).and_return(transaction_params)
-      allow(transaction_params).to receive(:as_json).and_return(transaction_params)
-      expect(transaction).to receive(:execute).with(transaction_params)
-
-      subject.execute_transaction
-    end
-  end
-end


### PR DESCRIPTION
**NOTE: This code is far from being cleaned up, complete, fully covered by tests. ATM it is more a request for discussion, and I do not expect it to be mergeable** 

I badly needed Hashes of Models in my project so I changed a good part of the relation implementation to to be able to support Hashes.

The approach used for supporting hashes is simple: Store the hash key as an attribute of the edge collection document.

The required changes were:
* The query used for relations was changed to include the edge attributes.
* Implementing a delegating mapper before the original mapper for the model gets hold of the resulting vertex data
* Refactoring of the Relation and Proxy class into a bunch of more specialized classes.
* Making the proxy more transparent by delegating all calls that are not from __Enumerable__ to the mapped query result (collection or model) and all calls that are defined by Guacamole to the underlying query. This makes the proxy behave more like a proxy for the model collection and less for just the query.

The code works for me right now. Tests are passed as well, so I expect it should work when used in existing applications.

There are some open issues like how to handle a Hash element that is saved on its own (i.e. writing the edge data from the :inverse side of the relation, as there is no real place to store the required key information in the contained model).

If extended, this approach would also allow collections/relations based on edges with attributes (weighted edges in graphs anybody?), which would require custom Array/Hash classes.

What do you think?

ATM I have to focus again on the implementation I am paid for :), so I cannot clean everything up right now...